### PR TITLE
add priest behavior with an example

### DIFF
--- a/features/priest.feature
+++ b/features/priest.feature
@@ -1,0 +1,8 @@
+# created by Fu at 2022/11/30
+Feature: 神父 出牌規則
+
+  Scenario: 玩家出神父 指定一位其他玩家後出牌
+    Given 玩家A 持有 神父 衛兵
+    Given 玩家B 持有 公主
+    When 玩家A 對 玩家B 出牌 神父
+    Then 玩家A 看到了玩家B的公主

--- a/features/priest.feature
+++ b/features/priest.feature
@@ -5,4 +5,4 @@ Feature: 神父 出牌規則
     Given 玩家A 持有 神父 衛兵
     Given 玩家B 持有 公主
     When 玩家A 對 玩家B 出牌 神父
-    Then 玩家A 看到了玩家B的公主
+    Then 玩家A 看到了 玩家B 的 公主

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -100,3 +100,11 @@ def player_error_play_this_card(context, player: str, card: str):
     assert result is False
     assert active_player.total_value_of_card == 0
 
+
+@then('{player_a} 看到了玩家B的公主')
+def player_get_opponent_hand(context, player_a):
+    player_a: Player = getattr(context, player_a)
+    assert player_a.seen_opponent is not None
+    assert player_a.seen_cards is not None
+
+

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -101,16 +101,12 @@ def player_error_play_this_card(context, player: str, card: str):
     assert active_player.total_value_of_card == 0
 
 
-# @then('{player_a} 看到了玩家B的公主')
-# def player_get_opponent_hand(context, player_a):
-#     player_a: Player = getattr(context, player_a)
-#     assert player_a.seen_opponent is not None
-#     assert player_a.seen_cards is not None
-
-
 @then('{player_a} 看到了 {player_b} 的 {card}')
-def player_get_opponent_hand(context, player_a, player_b, card):
+def player_saw_opponent_hand(context, player_a, player_b, card):
     active_player: Player = getattr(context, player_a)
     inactive_player: Player = getattr(context, player_b)
     card_will_be_checked = find_card_by_name(card)
-    assert active_player.is_seen_opponent_card(inactive_player, card_will_be_checked) is True
+    # check last seen_cards opponent name and card equal
+    assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
+    assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
+

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -101,10 +101,16 @@ def player_error_play_this_card(context, player: str, card: str):
     assert active_player.total_value_of_card == 0
 
 
-@then('{player_a} 看到了玩家B的公主')
-def player_get_opponent_hand(context, player_a):
-    player_a: Player = getattr(context, player_a)
-    assert player_a.seen_opponent is not None
-    assert player_a.seen_cards is not None
+# @then('{player_a} 看到了玩家B的公主')
+# def player_get_opponent_hand(context, player_a):
+#     player_a: Player = getattr(context, player_a)
+#     assert player_a.seen_opponent is not None
+#     assert player_a.seen_cards is not None
 
 
+@then('{player_a} 看到了 {player_b} 的 {card}')
+def player_get_opponent_hand(context, player_a, player_b, card):
+    active_player: Player = getattr(context, player_a)
+    inactive_player: Player = getattr(context, player_b)
+    card_will_be_checked = find_card_by_name(card)
+    assert active_player.is_seen_opponent_card(inactive_player, card_will_be_checked) is True

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from typing import List, Union
 
-from love_letter.models.cards import find_card_by_name
+from love_letter.models.cards import find_card_by_name, PriestCard
 from love_letter.web.dto import GuessCard, ToSomeoneCard
 
 
@@ -88,6 +88,8 @@ class Player:
         self.am_i_out: bool = False
         self.protected = False
         self.total_value_of_card: int = 0
+        self.seen_opponent: List[str] = []
+        self.seen_cards: List["Card"] = []
 
     def play_opponent_two_cards(
             self, opponent: "Player" = None, card_will_be_played: "Card" = None, with_card: "Card" = None
@@ -107,7 +109,11 @@ class Player:
             # TODO send completed event for player
             return
 
-        card_will_be_played.execute_with_card(opponent, with_card)
+        play_result = card_will_be_played.execute_with_card(opponent, with_card)
+        if card_will_be_played.name == PriestCard.name:
+            # todo: send opponent card information to player
+            self.seen_opponent.append(opponent.name)
+            self.seen_cards.append(play_result)
 
         # TODO postcondition: the player holds 1 card after played
         self.cards = list(filter(lambda x: x.name == card_will_be_played.name, self.cards))

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -83,7 +83,7 @@ class Game:
 
 @dataclass
 class Seen:
-    opponent: str
+    opponent_name: str
     card: Card
 
 
@@ -129,12 +129,6 @@ class Player:
         self.total_value_of_card += card_will_be_played.level
 
         return True
-
-    def is_seen_opponent_card(self, opponent: "Player", card_will_be_checked: "Card"):
-        # opponent and card should be the same
-        if self.seen_cards[-1].opponent == opponent.name and self.seen_cards[-1].card == card_will_be_checked:
-            return True
-        return False
 
     def out(self):
         self.am_i_out = True

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -10,6 +10,11 @@ class Card(metaclass=abc.ABCMeta):
         play the card to player with a card by rules
 
         Ex. the GuardCard needs to play with a card for guessing.
+
+        purely play the card to player(can be opponent or myself)
+        Ex. play priest_card to the other opponent.
+        Ex. play handmaid_card to myself.
+        Ex. play king_card to the other opponent.
         """
         return NotImplemented
 
@@ -30,6 +35,11 @@ class GuardCard(Card):
 class PriestCard(Card):
     name = '神父'
     level = 2
+
+    # purely play priest_card to one player(here is opponent) without using card(guess) function
+    # just return player.cards
+    def execute_with_card(self, player: "Player", card: "Card"):
+        return player.cards[0]
 
 
 class BaronCard(Card):


### PR DESCRIPTION
有個問題在這邊討論一下
昨天提到Player類別需要新增存放看了「誰」的「手牌」，因此有在該類別底下新增兩個屬性代表曾經看過誰與手牌
(可在code_review時看看是否要在包成一個dictionary，合併為一個屬性即可)
因此在feature中將Then 寫成：{玩家A} 看到了玩家B的公主 (只有玩家A是變數，並且判斷「誰」、「手牌」是否為空)

另外這邊註記寫成List的形式後，在通知的地方就要去判斷這是第一次還是第二次。不然就會出現
第一次提示：
* 玩家A 透過神父私下看了玩家B 的卡片 公主
第二次提示： (多提示了之前的情況）
* 玩家A 透過神父私下看了玩家B 的卡片 公主
* 玩家A 透過神父私下看了玩家C 的卡片 國王