### PR TITLE
Refactoring the method of discarding a card

### DIFF
--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -40,7 +40,9 @@ def player_hold_one_card(context, player_a, player_b, card1, card2):
     turn_player: Player = getattr(context, player_a)
     chosen_player: Player = getattr(context, player_b)
 
-    _do_play(turn_player, chosen_player, find_card_by_name(card1), find_card_by_name(card2))
+    turn_player.discard_card(chosen_player=chosen_player,
+                             discarded_card=find_card_by_name(card1),
+                             with_card=find_card_by_name(card2))
 
 
 @when('{player_a} 對 {player_b} 出牌 {card}')
@@ -94,7 +96,9 @@ def player_error_play_this_card(context, player: str, card: str):
     found_exception = False
     try:
         i_dont_care_who_is_the_player = Player()
-        _do_play(turn_player, i_dont_care_who_is_the_player, discarded_card, None)
+        turn_player.discard_card(chosen_player=i_dont_care_who_is_the_player,
+                                 discarded_card=discarded_card,
+                                 with_card=None)
     except ValueError as e:
         found_exception = True
         assert e.args[0] == "You can not discard by the rule"
@@ -124,4 +128,3 @@ def player_saw_opponent_hand(context, player_a, player_b, card):
     # check last seen_cards opponent name and card equal
     assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
     assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
-

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -115,3 +115,13 @@ def player_saw_opponent_hand(context, player_a, player_b, card):
 
 def _do_play(turn_player: Player, chosen_player: "Player", discarded_card: "Card", with_card: "Card"):
     turn_player.discard_card(chosen_player=chosen_player, discarded_card=discarded_card, with_card=with_card)
+
+@then('{player_a} 看到了 {player_b} 的 {card}')
+def player_saw_opponent_hand(context, player_a, player_b, card):
+    active_player: Player = getattr(context, player_a)
+    inactive_player: Player = getattr(context, player_b)
+    card_will_be_checked = find_card_by_name(card)
+    # check last seen_cards opponent name and card equal
+    assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
+    assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
+

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -109,22 +109,9 @@ def player_error_play_this_card(context, player: str, card: str):
 
 @then('{player_a} 看到了 {player_b} 的 {card}')
 def player_saw_opponent_hand(context, player_a, player_b, card):
-    active_player: Player = getattr(context, player_a)
-    inactive_player: Player = getattr(context, player_b)
+    turn_player: Player = getattr(context, player_a)
+    chosen_player: Player = getattr(context, player_b)
     card_will_be_checked = find_card_by_name(card)
     # check last seen_cards opponent name and card equal
-    assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
-    assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
-
-
-def _do_play(turn_player: Player, chosen_player: "Player", discarded_card: "Card", with_card: "Card"):
-    turn_player.discard_card(chosen_player=chosen_player, discarded_card=discarded_card, with_card=with_card)
-
-@then('{player_a} 看到了 {player_b} 的 {card}')
-def player_saw_opponent_hand(context, player_a, player_b, card):
-    active_player: Player = getattr(context, player_a)
-    inactive_player: Player = getattr(context, player_b)
-    card_will_be_checked = find_card_by_name(card)
-    # check last seen_cards opponent name and card equal
-    assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
-    assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
+    assert (turn_player.seen_cards[-1].opponent_name == chosen_player.name) is True
+    assert (turn_player.seen_cards[-1].card == card_will_be_checked) is True

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -30,37 +30,32 @@ def player_is_protected(context, player):
 
 @when('系統發牌給 {player} {card1}')
 def system_draw_card(context, player: str, card1: str):
-    active_player: Player = getattr(context, player)
+    turn_player: Player = getattr(context, player)
     draw_card = find_card_by_name(card1)
-    active_player.cards.append(draw_card)
+    turn_player.cards.append(draw_card)
 
 
 @when('{player_a} 對 {player_b} 出牌 {card1} 指定 {card2}')
 def player_hold_one_card(context, player_a, player_b, card1, card2):
-    active_player: Player = getattr(context, player_a)
-    inactive_player: Player = getattr(context, player_b)
+    turn_player: Player = getattr(context, player_a)
+    chosen_player: Player = getattr(context, player_b)
 
-    active_player.play_opponent_two_cards(inactive_player,
-                                          find_card_by_name(card1),
-                                          find_card_by_name(card2)
-                                          )
+    _do_play(turn_player, chosen_player, find_card_by_name(card1), find_card_by_name(card2))
 
 
 @when('{player_a} 對 {player_b} 出牌 {card}')
 def player_hold_one_card(context, player_a, player_b, card):
-    active_player: Player = getattr(context, player_a)
-    inactive_player: Player = getattr(context, player_b)
+    turn_player: Player = getattr(context, player_a)
+    chosen_player: Player = getattr(context, player_b)
 
-    active_player.play_opponent_two_cards(opponent=inactive_player,
-                                          card_will_be_played=find_card_by_name(card),
-                                          )
+    turn_player.discard_card(opponent=chosen_player, discarded_card=find_card_by_name(card))
 
 
 @when('{player} 出牌 {card1}')
 def player_play_card(context, player: str, card1: str):
-    active_player: Player = getattr(context, player)
-    card_will_be_played = find_card_by_name(card1)
-    result = active_player.play_opponent_two_cards(opponent=active_player, card_will_be_played=card_will_be_played)
+    turn_player: Player = getattr(context, player)
+    discarded_card = find_card_by_name(card1)
+    turn_player.discard_card(opponent=turn_player, discarded_card=discarded_card)
 
 
 @then('{player} 出局')
@@ -77,28 +72,35 @@ def player_not_out(context, player):
 
 @then('{player} 成功打出 {card}')
 def player_success_play_this_card(context, player: str, card: str):
-    active_player: Player = getattr(context, player)
-    card_will_be_played = find_card_by_name(card)
-    result = active_player.play_opponent_two_cards(card_will_be_played=card_will_be_played)
+    turn_player: Player = getattr(context, player)
+    discarded_card = find_card_by_name(card)
+    result = turn_player.discard_card(discarded_card=discarded_card)
 
     assert result is True
-    assert active_player.total_value_of_card == card_will_be_played.value
+    assert turn_player.total_value_of_card == discarded_card.value
 
 
 @then('{player} 丟棄手牌')
 def player_discard_card(context, player: str):
-    active_player: Player = getattr(context, player)
-    assert len(active_player.cards) == 0
+    turn_player: Player = getattr(context, player)
+    assert len(turn_player.cards) == 0
 
 
 @then('{player} 無法打出 {card}')
 def player_error_play_this_card(context, player: str, card: str):
-    active_player: Player = getattr(context, player)
-    card_will_be_played = find_card_by_name(card)
-    result = active_player.play_opponent_two_cards(card_will_be_played=card_will_be_played)
+    turn_player: Player = getattr(context, player)
+    discarded_card = find_card_by_name(card)
 
-    assert result is False
-    assert active_player.total_value_of_card == 0
+    found_exception = False
+    try:
+        i_dont_care_who_is_the_player = Player()
+        _do_play(turn_player, i_dont_care_who_is_the_player, discarded_card, None)
+    except ValueError as e:
+        found_exception = True
+        assert e.args[0] == "You can not discard by the rule"
+
+    assert found_exception
+    assert turn_player.total_value_of_card == 0
 
 
 @then('{player_a} 看到了 {player_b} 的 {card}')
@@ -110,3 +112,6 @@ def player_saw_opponent_hand(context, player_a, player_b, card):
     assert (active_player.seen_cards[-1].opponent_name == inactive_player.name) is True
     assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
 
+
+def _do_play(turn_player: Player, opponent: "Player", discarded_card: "Card", with_card: "Card"):
+    turn_player.discard_card(opponent=opponent, discarded_card=discarded_card, with_card=with_card)

--- a/features/steps/common.py
+++ b/features/steps/common.py
@@ -48,14 +48,14 @@ def player_hold_one_card(context, player_a, player_b, card):
     turn_player: Player = getattr(context, player_a)
     chosen_player: Player = getattr(context, player_b)
 
-    turn_player.discard_card(opponent=chosen_player, discarded_card=find_card_by_name(card))
+    turn_player.discard_card(chosen_player=chosen_player, discarded_card=find_card_by_name(card))
 
 
 @when('{player} 出牌 {card1}')
 def player_play_card(context, player: str, card1: str):
     turn_player: Player = getattr(context, player)
     discarded_card = find_card_by_name(card1)
-    turn_player.discard_card(opponent=turn_player, discarded_card=discarded_card)
+    turn_player.discard_card(chosen_player=turn_player, discarded_card=discarded_card)
 
 
 @then('{player} 出局')
@@ -113,5 +113,5 @@ def player_saw_opponent_hand(context, player_a, player_b, card):
     assert (active_player.seen_cards[-1].card == card_will_be_checked) is True
 
 
-def _do_play(turn_player: Player, opponent: "Player", discarded_card: "Card", with_card: "Card"):
-    turn_player.discard_card(opponent=opponent, discarded_card=discarded_card, with_card=with_card)
+def _do_play(turn_player: Player, chosen_player: "Player", discarded_card: "Card", with_card: "Card"):
+    turn_player.discard_card(chosen_player=chosen_player, discarded_card=discarded_card, with_card=with_card)

--- a/features/tutorial.feature
+++ b/features/tutorial.feature
@@ -1,6 +1,0 @@
-Feature: showing off behave
-
-  Scenario: run a simple test
-    Given we have behave installed
-    When we implement a test
-    Then behave will test it for us!

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -53,9 +53,9 @@ class Game:
             return
 
         turn_player: "Player" = self.find_player_by_id(player_id)
-        opponent: "Player" = self.find_player_by_id(action.opponent)
+        chosen_player: "Player" = self.find_player_by_id(action.chosen_player)
 
-        turn_player.discard_card(opponent=opponent, discarded_card=find_card_by_name(card_name),
+        turn_player.discard_card(chosen_player=chosen_player, discarded_card=find_card_by_name(card_name),
                                  with_card=find_card_by_name(action.guess_card))
 
     def find_player_by_id(self, player_id):
@@ -96,7 +96,7 @@ class Player:
         self.total_value_of_card: int = 0
         self.seen_cards: List[Seen] = []
 
-    def discard_card(self, opponent: "Player" = None, discarded_card: Card = None, with_card: "Card" = None):
+    def discard_card(self, chosen_player: "Player" = None, discarded_card: Card = None, with_card: "Card" = None):
         # TODO precondition: the player must hold 2 cards
         if len(self.cards) != 2:
             return False
@@ -105,11 +105,11 @@ class Player:
         if not any([True for c in self.cards if c.name == discarded_card.name]):
             return False
 
-        if opponent and opponent.protected:
+        if chosen_player and chosen_player.protected:
             # TODO send completed event for player
             return
 
-        discarded_card.discard(self, chosen_player=opponent, with_card=with_card)
+        discarded_card.discard(self, chosen_player=chosen_player, with_card=with_card)
 
         # TODO postcondition: the player holds 1 card after played
         self.cards = list(filter(lambda x: x.name == discarded_card.name, self.cards))

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -109,7 +109,7 @@ class Player:
             # TODO send completed event for player
             return
 
-        discarded_card.discard(self, chosen_player=chosen_player, with_card=with_card)
+        discarded_card.trigger_effect(self, chosen_player=chosen_player, with_card=with_card)
 
         # TODO postcondition: the player holds 1 card after played
         self.cards = list(filter(lambda x: x.name == discarded_card.name, self.cards))

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -55,9 +55,8 @@ class Game:
         turn_player: "Player" = self.find_player_by_id(player_id)
         opponent: "Player" = self.find_player_by_id(action.opponent)
 
-        turn_player.play_opponent_two_cards(opponent,
-                                            find_card_by_name(card_name),
-                                            find_card_by_name(action.guess_card))
+        turn_player.discard_card(opponent=opponent, discarded_card=find_card_by_name(card_name),
+                                 with_card=find_card_by_name(action.guess_card))
 
     def find_player_by_id(self, player_id):
         players = self.this_round_players()
@@ -97,36 +96,26 @@ class Player:
         self.total_value_of_card: int = 0
         self.seen_cards: List[Seen] = []
 
-    def play_opponent_two_cards(
-            self, opponent: "Player" = None, card_will_be_played: "Card" = None, with_card: "Card" = None
-    ):
+    def discard_card(self, opponent: "Player" = None, discarded_card: Card = None, with_card: "Card" = None):
         # TODO precondition: the player must hold 2 cards
         if len(self.cards) != 2:
             return False
 
         # Check will_be_played_card is in the hands
-        if not any([True for c in self.cards if c.name == card_will_be_played.name]):
-            return False
-
-        if card_will_be_played.can_not_play(self):
+        if not any([True for c in self.cards if c.name == discarded_card.name]):
             return False
 
         if opponent and opponent.protected:
             # TODO send completed event for player
             return
 
-        # play_result return opponent's hand_card in PRIEST case
-        play_result = card_will_be_played.execute_with_card(opponent, with_card)
-        if card_will_be_played.name == PriestCard.name:
-            # todo: send opponent card information to player
-            seen_card = Seen(opponent.name, play_result)
-            self.seen_cards.append(seen_card)
+        discarded_card.discard(self, chosen_player=opponent, with_card=with_card)
 
         # TODO postcondition: the player holds 1 card after played
-        self.cards = list(filter(lambda x: x.name == card_will_be_played.name, self.cards))
+        self.cards = list(filter(lambda x: x.name == discarded_card.name, self.cards))
         if len(self.cards) != 1:
             return False
-        self.total_value_of_card += card_will_be_played.value
+        self.total_value_of_card += discarded_card.value
 
         return True
 

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -28,11 +28,8 @@ class Card(metaclass=abc.ABCMeta):
 
     """
 
-    def can_not_play(self, player: "Player"):
-        return False
-
     @abc.abstractmethod
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         """
         play the card to player with a card by rules
 
@@ -54,7 +51,7 @@ class GuardCard(Card):
     value = 1
     quantity = 5
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         for card in chosen_player.cards:
             if with_card == card:
                 chosen_player.out()
@@ -65,7 +62,7 @@ class PriestCard(Card):
     value = 2
     quantity = 2
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         raise NotImplemented
 
 
@@ -74,7 +71,7 @@ class BaronCard(Card):
     value = 3
     quantity = 2
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         raise NotImplemented
 
 
@@ -83,7 +80,7 @@ class HandmaidCard(Card):
     value = 4
     quantity = 2
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         raise NotImplemented
 
 
@@ -98,7 +95,7 @@ class PrinceCard(Card):
     If the deck is empty, that player draws the card that was removed at the start of the round
     """
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         # choose self to discard the card in the hand
         for c in card_holder.cards:
             if c.name == "伯爵夫人":
@@ -117,7 +114,7 @@ class KingCard(Card):
     value = 6
     quantity = 1
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         for c in card_holder.cards:
             if c.name == "伯爵夫人":
                 raise ValueError("You can not discard by the rule")
@@ -138,7 +135,7 @@ class CountessCard(Card):
     She likes to play mind games....
     """
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         # nothing happen by the rule
         pass
 
@@ -148,7 +145,7 @@ class PrincessCard(Card):
     value = 8
     quantity = 1
 
-    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+    def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         card_holder.out()
 
 

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -63,7 +63,9 @@ class PriestCard(Card):
     quantity = 2
 
     def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
-        raise NotImplemented
+        from love_letter.models import Seen
+        seen_card = Seen(chosen_player.name, chosen_player.cards[-1])
+        card_holder.seen_cards.append(seen_card)
 
 
 class BaronCard(Card):

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -5,7 +5,12 @@ from typing import List
 
 class Card(metaclass=abc.ABCMeta):
     """
-    There are some properties in a card
+    A card could be discarded by the turn-player or a chosen player who was assigned by the turn player.
+    Either turn player or chosen player would take effect when the card is discarded.
+    Sometimes, nothing happen, it just a discarded card by the turn player.
+
+
+    There are some properties in a card:
 
     +---------+----------+
     | Value   | Name     |
@@ -26,7 +31,8 @@ class Card(metaclass=abc.ABCMeta):
     def can_not_play(self, player: "Player"):
         return False
 
-    def execute_with_card(self, player: "Player", card: "Card"):
+    @abc.abstractmethod
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         """
         play the card to player with a card by rules
 
@@ -48,10 +54,10 @@ class GuardCard(Card):
     value = 1
     quantity = 5
 
-    def execute_with_card(self, player: "Player", guessing_card: "Card"):
-        for card in player.cards:
-            if guessing_card == card:
-                player.out()
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        for card in chosen_player.cards:
+            if with_card == card:
+                chosen_player.out()
 
 
 class PriestCard(Card):
@@ -59,10 +65,8 @@ class PriestCard(Card):
     value = 2
     quantity = 2
 
-    # purely play priest_card to one player(here is opponent) without using card(guess) function
-    # just return player.cards
-    def execute_with_card(self, player: "Player", card: "Card"):
-        return player.cards[0]
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        raise NotImplemented
 
 
 class BaronCard(Card):
@@ -70,11 +74,17 @@ class BaronCard(Card):
     value = 3
     quantity = 2
 
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        raise NotImplemented
+
 
 class HandmaidCard(Card):
     name = '侍女'
     value = 4
     quantity = 2
+
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        raise NotImplemented
 
 
 class PrinceCard(Card):
@@ -82,14 +92,24 @@ class PrinceCard(Card):
     value = 5
     quantity = 2
 
-    def can_not_play(self, player: "Player"):
-        return COUNTESS_CARD in player.cards
+    """
+    When you discard Prince Arnaud, choose one player still in the round (including yourself). 
+    That player discards his or her hand (do not apply its effect) and draws a new card. 
+    If the deck is empty, that player draws the card that was removed at the start of the round
+    """
 
-    def execute_with_card(self, player: "Player", card: "Card"):
-        for card in player.cards:
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        # choose self to discard the card in the hand
+        for c in card_holder.cards:
+            if c.name == "伯爵夫人":
+                raise ValueError("You can not discard by the rule")
+
+        for card in chosen_player.cards:
             if "公主" == card.name:
-                player.out()
-        player.cards = []
+                chosen_player.out()
+
+        # TODO the game system should send a new card to the player who did discard
+        chosen_player.cards = []
 
 
 class KingCard(Card):
@@ -97,8 +117,10 @@ class KingCard(Card):
     value = 6
     quantity = 1
 
-    def can_not_play(self, player: "Player"):
-        return COUNTESS_CARD in player.cards
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        for c in card_holder.cards:
+            if c.name == "伯爵夫人":
+                raise ValueError("You can not discard by the rule")
 
 
 class CountessCard(Card):
@@ -106,7 +128,18 @@ class CountessCard(Card):
     value = 7
     quantity = 1
 
-    def execute_with_card(self, player: "Player", card: "Card"):
+    """
+    Unlike other cards, which take effect when discarded, the text on the Countess applies while she is in your hand. 
+    In fact, she has no effect when you discard her.
+
+    If you ever have the Countess and either the King or Prince in your hand, 
+    you must discard the Countess. You do not have to reveal the other card in your hand. 
+    Of course, you can also discard the Countess even if you do not have a royal family member in your hand. 
+    She likes to play mind games....
+    """
+
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        # nothing happen by the rule
         pass
 
 
@@ -115,8 +148,8 @@ class PrincessCard(Card):
     value = 8
     quantity = 1
 
-    def execute_with_card(self, player: "Player", card: "Card"):
-        player.out()
+    def discard(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
+        card_holder.out()
 
 
 def find_card_by_name(name):
@@ -174,4 +207,3 @@ ALL_CARD_TYPES = [
     CountessCard(),
     PrincessCard(),
 ]
-COUNTESS_CARD = find_card_by_name("伯爵夫人")

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -2,6 +2,8 @@ import abc
 import random
 from typing import List
 
+REJECT_BY_RULE = ValueError("You can not discard by the rule")
+
 
 class Card(metaclass=abc.ABCMeta):
     """
@@ -101,7 +103,7 @@ class PrinceCard(Card):
         # choose self to discard the card in the hand
         for c in card_holder.cards:
             if c.name == "伯爵夫人":
-                raise ValueError("You can not discard by the rule")
+                raise REJECT_BY_RULE
 
         for card in chosen_player.cards:
             if "公主" == card.name:
@@ -119,7 +121,7 @@ class KingCard(Card):
     def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
         for c in card_holder.cards:
             if c.name == "伯爵夫人":
-                raise ValueError("You can not discard by the rule")
+                raise REJECT_BY_RULE
 
 
 class CountessCard(Card):

--- a/love_letter/web/dto/__init__.py
+++ b/love_letter/web/dto/__init__.py
@@ -4,9 +4,9 @@ from pydantic import BaseModel
 
 
 class GuessCard(BaseModel):
-    opponent: str
+    chosen_player: str
     guess_card: str
 
 
 class ToSomeoneCard(BaseModel):
-    opponent: str
+    chosen_player: str

--- a/tests/test_simple_path_e2e.py
+++ b/tests/test_simple_path_e2e.py
@@ -34,7 +34,7 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
 
         # 玩家出牌
         request_body = {
-            "opponent": "player-b",
+            "chosen_player": "player-b",
             "guess_card": "神父"
         }
         response = self.t.post(f"/games/{game_id}/player/player-a/card/衛兵/play", json=request_body).json()


### PR DESCRIPTION
調整玩家 `丟棄手牌` 的 method signature，讓它同時符合不同的使用情境. 

三種情境可參考：
https://github.com/Game-as-a-Service/LoveLetter/issues/16#issuecomment-1330197000

## Method 名稱調整

### Player

原 method 名 `play_opponent_two_cards` 改名 `discard_card`，如規則書中的 `丟棄手牌`

```py
def discard_card(self, chosen_player: "Player" = None, discarded_card: Card = None, with_card: "Card" = None):
    pass
```


### Card

原 method 名 `execute_with_card` 改名為 `trigger_effect`，如果規則中的「丟棄卡片後，觸發效果..」

```py
@abc.abstractmethod
def trigger_effect(self, card_holder: "Player", chosen_player: "Player" = None, with_card: "Card" = None):
    return NotImplemented
```

為了讓 `Card` 被丟棄時，有需要的 Context：

1. 指定 `card_holder` 也就是持有者為 `必要參數`
2. 被選定的玩家 `chosen_player`，optional
3. 搭配使用的卡片 `with_card`，optional

## 以 Exception 取代 `can_not_play`

由於，我們不應該給玩家無法使用的選項，這個動作視為系統的例外。到時，做 Player Context 時再處理不合規則的問題。


## 術語調整 

### discard

以下為英文版部分規則

> When you discard Prince Arnaud, choose one player still in the round (including yourself). That player discards his or her hand (do not apply its effect) and draws a new card. If the deck is empty, that player draws the card that was removed at the start of the round.
If all other players are protected by the Handmaid,

* 採用 `discard` 動詞取代 `play_opponent_two_cards `。

### choose a player

以下為英文版部分規則

> When you discard the Guard, choose a player and name a card
(other than Guard). If that player has that card, that player is knocked out of the round. If all other players still in the round are protected by the Handmaid, this card does nothing.

* 採用 `chosen_player` 代表 `opponent`。
主要是 opponent 一直記不住，又看上了 rule 中選了 choose 作為動詞，乾脆改成 `chosen_player`