### PR TITLE
實作遊戲進行中的固定規則

### DIFF
--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -31,12 +31,19 @@ class Round:
             deck.draw(p)
         return deck
 
-    def next_turn_player(self):
-        self._shift_to_next_player()
+    def next_turn_player(self, last_winner: str = None):
+        self._shift_to_next_player(last_winner)
         self.deck.draw(self.turn_player)
         # TODO tell the game from return-value if the round has ended
 
-    def _shift_to_next_player(self):
+    def _shift_to_next_player(self, last_winner: str = None):
+        # assign the turn player from the last winner
+        if last_winner is not None:
+            for player in self.players:
+                if player.name == last_winner:
+                    self.turn_player = player
+                    return
+
         # TODO only shift to players who is not out
         if self.turn_player is None:
             # TODO pick a turn player randomly if no one is turn player *FOR NOW*
@@ -83,10 +90,10 @@ class Game:
 
         self.next_round()
 
-    def next_round(self):
+    def next_round(self, last_winner: str = None):
         # TODO 如果沒有下一局，丟 exception
         round = Round(deepcopy(self.players))
-        round.next_turn_player()
+        round.next_turn_player(last_winner)
         self.rounds.append(round)
 
     def to_dict(self):
@@ -107,8 +114,10 @@ class Game:
         # 出牌後，有玩家可能出局，剩最後一名玩家，它就是勝利者
         might_has_winner = [x for x in players if not x.am_i_out]
         if len(might_has_winner) == 1:
-            self.rounds[-1].winner = might_has_winner[0].name
-            self.next_round()
+            winner_name = might_has_winner[0].name
+            self.rounds[-1].winner = winner_name
+            self.next_round(winner_name)
+            return
         self.next_turn_player()
 
     def handle_when_guess_card_action(self, player_id: str, card_name: str, action: GuessCard):

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -45,11 +45,16 @@ class Round:
             return
 
         from_index = self.players.index(self.turn_player)
-        for next_index in range(from_index + 1, len(self.players)):
-            next_index = next_index % len(self.players)
-            if not self.players[next_index].am_i_out:
-                self.turn_player = self.players[next_index]
-                return
+        for x in range(1, len(self.players)):
+            from_index = from_index + 1
+            if from_index >= len(self.players):
+                selected = self.players[from_index - len(self.players)]
+            else:
+                selected = self.players[from_index]
+
+            if not selected.am_i_out:
+                self.turn_player = selected
+                break
 
     def to_dict(self):
         return dict(players=[x.to_dict() for x in self.players], winner=self.winner)
@@ -163,7 +168,7 @@ class Player:
 
     def __init__(self):
         self.name: str = None
-        self.cards: List["Card"] = []
+        self.cards: List[Card] = []
         self.am_i_out: bool = False
         self.protected = False
         self.total_value_of_card: int = 0
@@ -185,7 +190,7 @@ class Player:
         discarded_card.trigger_effect(self, chosen_player=chosen_player, with_card=with_card)
 
         # TODO postcondition: the player holds 1 card after played
-        self.cards = list(filter(lambda x: x.name != discarded_card.name, self.cards))
+        self.drop_card(discarded_card)
 
         if len(self.cards) != 1:
             return False
@@ -202,8 +207,18 @@ class Player:
     def __eq__(self, other):
         return self.name == other.name
 
+    def __repr__(self):
+        return f"Player({self.name},{self.cards})"
+
     @classmethod
     def create(cls, name):
         p = Player()
         p.name = name
         return p
+
+    def drop_card(self, discarded_card: Card):
+        # only drop 1 card
+        for index, card in enumerate(self.cards):
+            if card.name == discarded_card.name:
+                self.cards.pop(index)
+                break

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -58,7 +58,7 @@ class Round:
             return
 
         from_index = self.players.index(self.turn_player)
-        for x in range(1, len(self.players)):
+        for _ in range(1, len(self.players)):
             from_index = from_index + 1
             if from_index >= len(self.players):
                 selected = self.players[from_index - len(self.players)]

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -39,6 +39,7 @@ class Round:
         1. the deck is empty will cause the round ended
         1. only one player alive will cause the round ended
         """
+        # TODO should fix the side effect (when empty deck, it should not be moved) before making player-context
         self._shift_to_next_player(last_winner)
         return self.deck.draw(self.turn_player)
 
@@ -127,6 +128,7 @@ class Game:
 
         has_next_player = self.next_turn_player()
         if not has_next_player:
+            # TODO it doesn't cover the case: two players own same card but different total values (score)
             # find the winner from the alive players
             winner = max(might_has_winner)
             self.rounds[-1].winner = winner.name

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -1,3 +1,4 @@
+import secrets
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Union
@@ -51,11 +52,9 @@ class Round:
                     self.turn_player = player
                     return
 
-        # TODO only shift to players who is not out
+        # pick up a player for the first round
         if self.turn_player is None:
-            # TODO pick a turn player randomly if no one is turn player *FOR NOW*
-            # TODO fix it by rules 1. first round => randomly, 2. non-first round, pick last winner as the turn player
-            self.turn_player = self.players[0]
+            self.turn_player = Round.choose_one_randomly(self.players)
             return
 
         from_index = self.players.index(self.turn_player)
@@ -69,6 +68,10 @@ class Round:
             if not selected.am_i_out:
                 self.turn_player = selected
                 break
+
+    @classmethod
+    def choose_one_randomly(cls, players: List["Player"]):
+        return players[secrets.randbelow(len(players))]
 
     def to_dict(self):
         return dict(players=[x.to_dict() for x in self.players], winner=self.winner)

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Union
 

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -98,7 +98,7 @@ class Game:
         self.next_round()
 
     def next_round(self, last_winner: str = None):
-        # TODO 如果沒有下一局，丟 exception
+        # TODO if we arrive the ending of the game, show the lucky person who won the Princess
         round = Round(deepcopy(self.players))
         round.next_turn_player(last_winner)
         self.rounds.append(round)

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Union
 

--- a/love_letter/models/cards.py
+++ b/love_letter/models/cards.py
@@ -192,13 +192,16 @@ class Deck:
         for num in range(remove_cards_num):
             self.remove_by_rule_cards.append(self.cards.pop(0))
 
-    def draw(self, player: "Player"):
+    def draw(self, player: "Player") -> bool:
         """
         Player draw the top card.
         :param player:
         :return:
         """
+        if len(self.cards) == 0:
+            return False
         player.cards.append(self.cards.pop(0))
+        return True
 
 
 ALL_CARD_TYPES = [

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -92,7 +92,7 @@ class GetGameStartedTests(TestCase):
         self.assertEqual("Game Has No Capacity For New Players", self.exception_message)
 
 
-class PlayingGameTests(TestCase):
+class PlayingGameInRoundTests(TestCase):
 
     def setUp(self):
         # make a game with 3 players
@@ -157,3 +157,17 @@ class PlayingGameTests(TestCase):
 
         # then the turn player earns 2 points by discarding 衛兵 twice
         self.assertEqual(2, self.game.rounds[-1].turn_player.total_value_of_card)
+
+    def test_move_to_next_round_by_only_one_player_alive(self):
+        """
+        當只剩下 1 名玩家存活時，此玩家為 winner，讓此局結束開始新的一局
+        """
+        # TODO
+        raise NotImplemented
+
+    def test_move_to_next_round_by_empty_deck(self):
+        """
+        當牌庫已空時，決定最後的 winner。讓此局結束開始新的一局
+        """
+        # TODO 
+        raise NotImplemented

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -1,4 +1,5 @@
 import math
+from collections import Counter
 from typing import Callable, List
 from unittest import TestCase
 
@@ -226,18 +227,12 @@ class FirstRoundRandomPickerTests(TestCase):
         return game
 
     def test_uniform_random_picker(self):
-        runs = 512
-        name_list = []
-        for x in range(runs):
+        counter = Counter()
+        for _ in range(100):
             game = self.create_game()
             game.start()
-            name_list.append(game.get_turn_player().name)
+            counter.update({game.get_turn_player().name: 1})
 
-        # divide to 4 groups
-        count_for_each_group = runs / 4
-        # tolerance for 30% (the random generator is not real fair)
-        tolerance = 0.3
-        for x in range(1, 5):
-            distance = math.fabs(1 - (name_list.count(str(x)) / count_for_each_group))
-            print(f"distance for player({x}) between 1 and real value was: {distance}")
-            self.assertLess(distance, tolerance)
+        # any player has the chance to be the turn player
+        for value in counter.values():
+            self.assertTrue(value > 1)

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -1,19 +1,29 @@
-from typing import Callable
+from typing import Callable, List
 from unittest import TestCase
 
-from love_letter.models import Game, GameException, Player
+from love_letter.models import Deck, Game, GameException, Player
+from love_letter.web.dto import GuessCard
+
+
+def reset_deck(card_name_list: List[str]):
+    class _TestDeck(Deck):
+        def shuffle(self, player_num: int):
+            super().shuffle(player_num)
+            from love_letter.models import find_card_by_name as c
+            self.cards = [c(x) for x in card_name_list]
+
+    import love_letter.models
+    love_letter.models.deck_factory = lambda: _TestDeck()
 
 
 class GetGameStartedTests(TestCase):
 
     def setUp(self):
-        self.exception: BaseException = None
         self.exception_message: str = None
 
     def catch(self, callable: Callable):
         with self.assertRaises(BaseException) as ex:
             callable()
-        self.exception = ex.exception
         self.exception_message = str(ex.exception)
 
     def test_game_can_not_start_less_than_two_players(self):
@@ -80,3 +90,70 @@ class GetGameStartedTests(TestCase):
 
         # then it got error
         self.assertEqual("Game Has No Capacity For New Players", self.exception_message)
+
+
+class PlayingGameTests(TestCase):
+
+    def setUp(self):
+        # make a game with 3 players
+        game: Game = Game()
+        game.join(Player.create('1'))
+        game.join(Player.create('2'))
+        game.join(Player.create('3'))
+        self.game: Game = game
+
+    def test_after_game_start_every_player_get_1_card_and_turn_player_get_extra_1(self):
+        """
+        遊戲開始後，人人獲得一張手牌。
+        turn player 會再多一張手牌
+        """
+
+        # given the arranged deck
+        reset_deck([
+            '王子',  # player 1
+            '神父',  # player 2
+            '公主',  # player 3
+            '衛兵',  # turn player owns it
+            '衛兵',
+            '衛兵',
+            '衛兵',
+        ])
+
+        # when start the arranged game
+        self.game.start()
+
+        # then player get the expected cards
+        expected_card_mapping = [('1', ['王子', '衛兵']), ('2', ['神父']), ('3', ['公主'])]
+        for index, player in enumerate(self.game.this_round_players()):
+            name, cards = expected_card_mapping[index]
+            self.assertEqual(name, player.name)
+            self.assertEqual(cards, [x.name for x in player.cards])
+
+    def test_shift_turn_player_one_by_one(self):
+        """
+        出牌後，完成觸發效果就換下一位。
+        試著都沒有人出局的情況下，是否會輪回第 1 個玩家
+        """
+
+        # given the arranged deck (塞 1 百個衛兵在牌庫)
+        reset_deck(list(['衛兵' for x in range(100)]))
+
+        # given a started game
+        self.game.start()
+
+        # when 3 player discarded twice but nothing happened
+        self.game.play('1', '衛兵', GuessCard(chosen_player='2', guess_card='公主'))
+        self.game.play('2', '衛兵', GuessCard(chosen_player='3', guess_card='公主'))
+        self.game.play('3', '衛兵', GuessCard(chosen_player='1', guess_card='公主'))
+        self.game.play('1', '衛兵', GuessCard(chosen_player='2', guess_card='公主'))
+        self.game.play('2', '衛兵', GuessCard(chosen_player='3', guess_card='公主'))
+        self.game.play('3', '衛兵', GuessCard(chosen_player='1', guess_card='公主'))
+
+        # then the game is still at round 1
+        self.assertEqual(1, len(self.game.rounds))
+
+        # then the turn player back to the player 1
+        self.assertEqual('1', self.game.rounds[-1].turn_player.name)
+
+        # then the turn player earns 2 points by discarding 衛兵 twice
+        self.assertEqual(2, self.game.rounds[-1].turn_player.total_value_of_card)

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -186,5 +186,20 @@ class PlayingGameRoundByRoundTests(TestCase):
         """
         當牌庫已空時，決定最後的 winner。讓此局結束開始新的一局
         """
-        # TODO
-        raise NotImplemented
+
+        # given the arranged deck
+        reset_deck(['伯爵夫人', '公主', '國王', '衛兵'])
+
+        # given a started game
+        self.game.start()
+
+        # when the deck become empty
+        self.game.play('1', '衛兵',  # player-1 kill nobody
+                       GuessCard(chosen_player='2', guess_card='侍女'))
+
+        # then player-2 is winner because 公主 is the card of the highest value (8)
+        #   1. the winner of the last round
+        #   2. the turn player at the new round
+        self.assertEqual(2, len(self.game.rounds))  # there are two rounds
+        self.assertEqual('2', self.game.rounds[-2].winner)  # the last round winner
+        self.assertEqual('2', self.game.rounds[-1].turn_player.name)  # turn player of this round

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -1,7 +1,7 @@
 from typing import Callable, List
 from unittest import TestCase
 
-from love_letter.models import Deck, Game, GameException, Player
+from love_letter.models import Deck, Game, Player
 from love_letter.web.dto import GuessCard
 
 
@@ -92,7 +92,7 @@ class GetGameStartedTests(TestCase):
         self.assertEqual("Game Has No Capacity For New Players", self.exception_message)
 
 
-class PlayingGameInRoundTests(TestCase):
+class PlayingGameRoundByRoundTests(TestCase):
 
     def setUp(self):
         # make a game with 3 players
@@ -162,12 +162,29 @@ class PlayingGameInRoundTests(TestCase):
         """
         當只剩下 1 名玩家存活時，此玩家為 winner，讓此局結束開始新的一局
         """
-        # TODO
-        raise NotImplemented
+
+        # given the arranged deck
+        reset_deck(['伯爵夫人', '國王', '王子'] + list(['衛兵' for x in range(10)]))
+
+        # given a started game
+        self.game.start()
+
+        # when the game has only 1 player alive
+        self.game.play('1', '衛兵',  # player-1 kill player-2
+                       GuessCard(chosen_player='2', guess_card='國王'))
+        self.game.play('3', '衛兵',  # player-3 kill player-1
+                       GuessCard(chosen_player='1', guess_card='伯爵夫人'))
+
+        # then the player-3 will be
+        #   1. the winner of the last round
+        #   2. the turn player at the new round
+        self.assertEqual(2, len(self.game.rounds))  # there are two rounds
+        self.assertEqual('3', self.game.rounds[-2].winner)  # the last round winner
+        self.assertEqual('3', self.game.rounds[-1].turn_player.name)  # turn player of this round
 
     def test_move_to_next_round_by_empty_deck(self):
         """
         當牌庫已空時，決定最後的 winner。讓此局結束開始新的一局
         """
-        # TODO 
+        # TODO
         raise NotImplemented

--- a/tests/test_game_rules.py
+++ b/tests/test_game_rules.py
@@ -141,7 +141,7 @@ class PlayingGameRoundByRoundTests(TestCase):
         # given a started game
         self.game.start()
 
-        # when 3 player discarded twice but nothing happened
+        # when 3 players discarded twice but nothing happened
         self.game.play('1', '衛兵', GuessCard(chosen_player='2', guess_card='公主'))
         self.game.play('2', '衛兵', GuessCard(chosen_player='3', guess_card='公主'))
         self.game.play('3', '衛兵', GuessCard(chosen_player='1', guess_card='公主'))

--- a/tests/test_simple_path_e2e.py
+++ b/tests/test_simple_path_e2e.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from fastapi.testclient import TestClient
 
-from love_letter.models import Deck
+from love_letter.models import Deck, Round
 
 
 def _test_client() -> TestClient:
@@ -28,8 +28,13 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.t: TestClient = _test_client()
+        # disable random-picker for the first round
+        # it always returns the first player
+        self.origin_choose_one_randomly = Round.choose_one_randomly
+        Round.choose_one_randomly = lambda x: x[0]
 
     def tearDown(self) -> None:
+        Round.choose_one_randomly = self.origin_choose_one_randomly
         self.t.close()
 
     def test_start_game_with_predefined_state(self):


### PR DESCRIPTION
#19 的後半部到 `結束遊戲` 之前

## 原來的需求描述

### 遊戲開始之後

1. 遊戲開始後，會自動建立新局。而玩家加入遊戲的順序，即為位局之中的位置順序。
2. 當局中只剩 1 名存活玩家，或達成「此局結束條件」時，遊戲會自動結束此局，再開啟新的「局」。
3. 遊戲自動開新局只會在未達遊戲結束條件時發生

### 局 Round 的開始

1. 局是由遊戲產生的並管理的
2. 第 1 局的第 1 個行動玩家是亂數指定的
3. 第 1 局之後的第一個行動玩家，是由上一局贏家獲得
4. 行動玩家會由系統自動幫他在 `牌庫` 中抽一張牌 (行動完家的特徵之一就是有 2 張牌，並且在完成行動前，不會有另一個人也有 2 張牌)

## 實作的項目

- [x] turn player 會多 1 張手牌
- [x] 在同一局中，可以多次輪流到初始玩家，並持續累計分數
- [x] 一局只剩 1 名玩家時，會找出 winner，自動進入下一局或結束遊戲
- [x] 牌庫沒牌時，會找出 winner，自動進入下一局或結束遊戲
- [x] 第 2 局之後的初始 turn player 都是上一局的玩家
- [x] 第 1 局的第 1 個行動玩家是亂數指定的

----

## To Reviewers

判斷 `遊戲結束` 先不包含在這此的範圍。

- [ ] ~~經過 N 局後，達遊戲結束條件，獲得最後的贏家~~