### PR TITLE
實作建立遊戲與加入遊戲

### DIFF
--- a/love_letter/repository/__init__.py
+++ b/love_letter/repository/__init__.py
@@ -1,0 +1,32 @@
+import abc
+import uuid
+
+from love_letter.models import Game
+
+
+class GameRepository(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def save_or_update(self, game: Game):
+        pass
+
+    @abc.abstractmethod
+    def get(self, game_id) -> Game:
+        pass
+
+
+class GameRepositoryInMemoryImpl(GameRepository):
+
+    def __init__(self):
+        self.in_memory_data = dict()
+
+    def save_or_update(self, game: Game) -> str:
+        if game.id:
+            self.in_memory_data[game.id] = game
+        else:
+            game.id = uuid.uuid4().hex
+            self.in_memory_data[game.id] = game
+        return game.id
+
+    def get(self, game_id) -> Game:
+        return self.in_memory_data.get(game_id)

--- a/love_letter/service/__init__.py
+++ b/love_letter/service/__init__.py
@@ -1,44 +1,43 @@
+import traceback
 from typing import Dict, Optional, Union
 
 from love_letter.models import Game, Player
+from love_letter.repository import GameRepository
 from love_letter.web.dto import GuessCard, ToSomeoneCard
-
-database = dict()
-
-
-def build_fake_data():
-    global database
-
-    game = Game()
-    game.id = 'g-5566'
-    database['g-5566'] = game
-
-    player_a = Player()
-    player_a.name = 'player-a'
-    player_a.cards = []
-    game.join(player_a)
-
-    player_b = Player()
-    player_b.name = 'player-b'
-    player_b.cards = []
-    game.join(player_b)
-
-
-build_fake_data()
 
 
 class GameService:
+
+    def __init__(self, repository: GameRepository):
+        self.repository = repository
+
+    def create_game(self, player_id: str) -> str:
+        game = Game()
+        # TODO for now, we dont have the registration process,
+        # TODO just create the player when they are creating or joining the game
+        game.join(Player.create(player_id))
+        return self.repository.save_or_update(game)
+
+    def join_game(self, game_id: str, player_id: str) -> bool:
+        try:
+            self.repository.get(game_id).join(Player.create(player_id))
+            return True
+        except:
+            traceback.print_tb()
+            return False
+
     def start_game(self, game_id: str) -> Optional[Dict]:
-        if game_id not in database:
+        game: Game = self.repository.get(game_id)
+        if game is None:
             return
-        game: Game = database.get(game_id)
         game.start()
         return game.to_dict()
 
     def play_card(self, game_id, player_id: str, card_name: str,
                   card_action: Union[GuessCard, ToSomeoneCard, None]) -> Optional[Dict]:
-        if game_id in database:
-            game: Game = database.get(game_id)
-            game.play(player_id, card_name, card_action)
-            return game.to_dict()
-        return
+
+        game: Game = self.repository.get(game_id)
+        if game is None:
+            return
+        game.play(player_id, card_name, card_action)
+        return game.to_dict()

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -2,11 +2,22 @@ from typing import Union
 
 from fastapi import FastAPI
 
+from love_letter.repository import GameRepositoryInMemoryImpl
 from love_letter.service import GameService
 from love_letter.web.dto import GuessCard, ToSomeoneCard
 
 app = FastAPI()
-service = GameService()
+service = GameService(GameRepositoryInMemoryImpl())
+
+
+@app.post("/games/create/by_player/{player_id}")
+async def create_game(player_id: str) -> str:
+    return service.create_game(player_id)
+
+
+@app.post("/games/{game_id}/player/{player_id}/join")
+async def join_game(game_id: str, player_id: str) -> bool:
+    return service.join_game(game_id, player_id)
 
 
 @app.post("/games/{game_id}/start")

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -1,0 +1,28 @@
+import unittest
+
+from love_letter.models import Player
+from love_letter.repository import GameRepositoryInMemoryImpl
+from love_letter.service import GameService
+
+
+class GameServiceTests(unittest.TestCase):
+
+    def test_create_and_join_game(self):
+        service = GameService(GameRepositoryInMemoryImpl())
+
+        # create a new game
+        game_id = service.create_game(Player.create("1"))
+        self.assertIsNotNone(game_id)
+
+        # join the second player
+        self.assertTrue(service.join_game(game_id, Player.create("2")))
+        result = service.start_game(game_id)
+
+        # check the game status
+        self.assertEqual(game_id, result.get('game_id'))
+        self.assertEqual(2, len(result.get('players')))
+
+        # check two players' id
+        names = [player.get('name') for player in result.get('players')]
+        # TODO figure out why it becomes Player(<id>,[]) form?
+        self.assertEqual("[Player(1,[]), Player(2,[])]", str(names))

--- a/tests/test_simple_path_e2e.py
+++ b/tests/test_simple_path_e2e.py
@@ -38,16 +38,24 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
         self.t.close()
 
     def test_start_game_with_predefined_state(self):
-        game_id = "g-5566"
+        player_a = "player-a"
+        player_b = "player-b"
 
         # 將牌庫換成測試用牌庫
         import love_letter.models
         love_letter.models.deck_factory = lambda: TestDeck()
 
+        # 建立遊戲
+        game_id = self.t.post(f"/games/create/by_player/{player_a}").json()
+
+        # 加入遊戲
+        is_success = self.t.post(f"/games/{game_id}/player/{player_b}/join").json()
+        self.assertTrue(is_success)
+
         # 開始遊戲
         response = self.t.post(f"/games/{game_id}/start").json()
         self.assertEqual(dict(
-            game_id="g-5566",
+            game_id=game_id,
             players=[dict(name="player-a", out=False), dict(name="player-b", out=False)],
             rounds=[
                 dict(
@@ -64,7 +72,7 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
         }
         response = self.t.post(f"/games/{game_id}/player/player-a/card/衛兵/play", json=request_body).json()
         self.assertEqual(dict(
-            game_id="g-5566",
+            game_id=game_id,
             players=[dict(name="player-a", out=False), dict(name="player-b", out=False)],
             rounds=[
                 dict(


### PR DESCRIPTION
#45 

## 設計摘要

* 目前沒有 `帳號註冊` 的概念，只要玩家 `建立遊戲` 或 `加入遊戲`，我們都幫他們建立臨時的 Player 物件。
* 使用 Repository 取代先前的 `fake_database`，開成介面與實作，預留替換成 mongodb 的位置。