### PR TITLE
[Bug] Starting player error

### DIFF
--- a/frontend/src/components/GameEvents.tsx
+++ b/frontend/src/components/GameEvents.tsx
@@ -45,7 +45,7 @@ function RoundEventView(props: { event: GameEvent; index: number }) {
     annotated = (
       <>
         <Badge variant="solid" colorScheme="messenger" ml={2}>
-          {context.GetTurnPlayer().name}
+          {context.GetStartPlayer()}
         </Badge>
         <Box ml={2}>為起始玩家</Box>
       </>

--- a/frontend/src/providers/index.tsx
+++ b/frontend/src/providers/index.tsx
@@ -15,6 +15,7 @@ export interface GameInformation {
   GetTurnPlayer: () => TurnPlayer;
 
   IsMyTurn: () => boolean;
+  GetStartPlayer: () => string;
 }
 
 class BeforeReadyGameInformation implements GameInformation {
@@ -42,6 +43,10 @@ class BeforeReadyGameInformation implements GameInformation {
 
   IsMyTurn(): boolean {
     return false;
+  }
+
+  GetStartPlayer(): string {
+    return this.unknown;
   }
 }
 
@@ -78,6 +83,14 @@ class ConcreteGameInformation implements GameInformation {
 
   IsMyTurn(): boolean {
     return this.GetTurnPlayer().name === this.username;
+  }
+
+  GetStartPlayer(): string {
+    if (this.gameStatus.rounds.length === 0) {
+      return "<unknown>";
+    }
+
+    return this.gameStatus.rounds[this.gameStatus.rounds.length - 1].start_player;
   }
 
   gameId: string;

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -40,4 +40,5 @@ export interface HandCard {
 export interface Round {
   turn_player: TurnPlayer;
   players: Array<RoundPlayer>;
+  start_player: string;
 }

--- a/love_letter/models/__init__.py
+++ b/love_letter/models/__init__.py
@@ -16,6 +16,7 @@ def deck_factory() -> Deck:
 class Round:
     winner: Optional[str] = None
     turn_player: Optional["Player"] = None
+    start_player: str
 
     def __init__(self, players: List["Player"]):
         self.players: List["Player"] = players
@@ -54,11 +55,13 @@ class Round:
             for player in self.players:
                 if player.name == last_winner:
                     self.turn_player = player
+                    self.start_player = self.turn_player.name
                     return
 
         # pick up a player for the first round
         if self.turn_player is None:
             self.turn_player = Round.choose_one_randomly(self.players)
+            self.start_player = self.turn_player.name
             return
 
         from_index = self.players.index(self.turn_player)
@@ -106,6 +109,7 @@ class Round:
             players=[x.to_dict() for x in self.players],
             winner=self.winner,
             turn_player=turn_player,
+            start_player=self.start_player,
         )
 
 

--- a/love_letter/web/dto/__init__.py
+++ b/love_letter/web/dto/__init__.py
@@ -35,6 +35,7 @@ class RoundModel(BaseModel):
     players: List[PlayerModel]
     winner: str | None
     turn_player: PlayerModel
+    start_player: str
 
 
 class NamedPlayer(BaseModel):

--- a/tests/test_simple_path_e2e.py
+++ b/tests/test_simple_path_e2e.py
@@ -150,6 +150,7 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
                             "out": False,
                         },
                         "winner": None,
+                        "start_player": "player-a",
                     }
                 ],
             },
@@ -236,6 +237,7 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
                             "out": False,
                         },
                         "winner": "player-a",
+                        "start_player": "player-a",
                     },
                     {
                         "players": [
@@ -317,6 +319,7 @@ class LoveLetterSimpleCaseEndToEndTests(unittest.TestCase):
                             "out": False,
                         },
                         "winner": None,
+                        "start_player": "player-a",
                     },
                 ],
             },


### PR DESCRIPTION
- 修正起始玩家顯示錯誤，增加每一round底下的`start_player`資料
- 一開始
![image](https://user-images.githubusercontent.com/44540755/215759856-34910547-e312-4915-8be3-a3ec806384fa.png)
- 第一位玩家出牌後 
![image](https://user-images.githubusercontent.com/44540755/215759996-e6766a4f-2190-4d32-a4b9-c6f65389338f.png)