### PR TITLE
Fix/persists states to prevent unnecessary re-renders

### DIFF
--- a/frontend/src/apis/index.tsx
+++ b/frontend/src/apis/index.tsx
@@ -1,7 +1,7 @@
 import axios, { RawAxiosRequestHeaders } from "axios";
 
-import { isEmpty } from "lodash";
 import { GameStatus } from "@/types";
+import isEmpty from "lodash/isEmpty";
 
 export const defaultHeaders: RawAxiosRequestHeaders = {
   Accept: "application/json",

--- a/frontend/src/components/Cards.tsx
+++ b/frontend/src/components/Cards.tsx
@@ -1,12 +1,12 @@
-import card_front from "./card-front.png";
 import card_back from "./card-back.png";
+import card_front from "./card-front.png";
 
 import { Button, Select } from "@chakra-ui/react";
 import { useRef } from "react";
 
+import { playCard } from "@/apis";
 import { useGameId, useUsername } from "@/hooks";
 import { HandCard } from "@/types";
-import { playCard } from "@/apis";
 
 export function CardBack(props: { enabled: boolean }) {
   let cssConfig = {};
@@ -33,7 +33,7 @@ export function CardAction(props: { handCard: HandCard }) {
   const ref_guessed_card = useRef(null);
 
   if (!handCard.usage.can_discard) {
-    return <></>;
+    return null;
   }
 
   const has_player_options = handCard.usage.choose_players.length > 0;
@@ -51,7 +51,9 @@ export function CardAction(props: { handCard: HandCard }) {
           }}
         >
           {handCard.usage.choose_players.map((x) => (
-            <option value={x} key={x}>{x}</option>
+            <option value={x} key={x}>
+              {x}
+            </option>
           ))}
         </Select>
       )}
@@ -65,7 +67,9 @@ export function CardAction(props: { handCard: HandCard }) {
           }}
         >
           {handCard.usage.can_guess_cards.map((x) => (
-            <option value={x} key={x}>{x}</option>
+            <option value={x} key={x}>
+              {x}
+            </option>
           ))}
         </Select>
       )}
@@ -102,7 +106,11 @@ export function CardFront(props: { handCard: HandCard }) {
 
   return (
     <div className="w-[118px] h-[172px] shadow-xl shadow-zinc-500 container relative">
-      <img src={card_front} className="bg-white rounded-xl" />
+      <img
+        alt={handCard.name}
+        src={card_front}
+        className="bg-white rounded-xl"
+      />
       <div className="flex flex-col absolute top-[15px] p-2 text-white items-center">
         <div className="text-xs mb-1">{handCard.value}</div>
         <div className="text-2xl">{handCard.name}</div>

--- a/frontend/src/components/CreateOrJoinGame.tsx
+++ b/frontend/src/components/CreateOrJoinGame.tsx
@@ -1,9 +1,9 @@
 import { Button, Flex, Input, Spacer } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
+import { createGame, isGameAvailable, joinGame } from "@/apis";
 import { useGameId, useUsername } from "@/hooks";
 import { ViewState } from "@/types";
-import { createGame, isGameAvailable, joinGame } from "@/apis";
 
 export function CreateOrJoinGame(props: {
   visitFunc: (view: ViewState) => void;
@@ -22,7 +22,7 @@ export function CreateOrJoinGame(props: {
         }
       });
     }
-  }, []);
+  }, [roomId, setRoomId, username]);
 
   return (
     <>

--- a/frontend/src/components/GameEvents.tsx
+++ b/frontend/src/components/GameEvents.tsx
@@ -1,8 +1,8 @@
-import React, { useContext } from "react";
-import { Badge, Box } from "@chakra-ui/react";
-import new_icon from "./icons8-new-60.png";
-import { GameEvent } from "@/types";
 import { GameContext } from "@/providers";
+import { GameEvent } from "@/types";
+import { Badge, Box } from "@chakra-ui/react";
+import { useContext } from "react";
+import new_icon from "./icons8-new-60.png";
 
 function NewIcon(props: { display: boolean }) {
   // source: https://icons8.com/icons/set/new
@@ -115,23 +115,23 @@ function CardEventView(props: { event: GameEvent; index: number }) {
 }
 
 function GameOverView(props: { event: GameEvent; index: number }) {
-    const { event, index } = props;
+  const { event, index } = props;
 
-    if (event.type !== "game_over") {
-        return <></>;
-    }
+  if (event.type !== "game_over") {
+    return <></>;
+  }
 
-    return (
-        <div className="m-1 p-2 min-h-[1rem] pl-3 rounded-xl flex items-center text-[12px]">
-            <Badge variant="solid" colorScheme="blackAlpha">
-                game over
-            </Badge>
-            <Badge variant="solid" colorScheme="red" ml={2}>
-                {event.final_winner}
-            </Badge>
-            <Box ml={2}>成為最終贏家</Box>
-        </div>
-    )
+  return (
+    <div className="m-1 p-2 min-h-[1rem] pl-3 rounded-xl flex items-center text-[12px]">
+      <Badge variant="solid" colorScheme="blackAlpha">
+        game over
+      </Badge>
+      <Badge variant="solid" colorScheme="red" ml={2}>
+        {event.final_winner}
+      </Badge>
+      <Box ml={2}>成為最終贏家</Box>
+    </div>
+  );
 }
 
 function CardActionItem(props: { event: GameEvent; index: number }) {

--- a/frontend/src/components/GameEvents.tsx
+++ b/frontend/src/components/GameEvents.tsx
@@ -24,7 +24,7 @@ function RoundEventView(props: { event: GameEvent; index: number }) {
   if (!context.isReady()) {
     return <></>;
   }
-  const { event, index } = props;
+  const { event } = props;
 
   if (event.type !== "round_started") {
     return <></>;
@@ -63,7 +63,7 @@ function RoundEventView(props: { event: GameEvent; index: number }) {
 }
 
 function CardEventView(props: { event: GameEvent; index: number }) {
-  const { event, index } = props;
+  const { event } = props;
 
   if (event.type !== "card_action") {
     return <></>;
@@ -115,7 +115,7 @@ function CardEventView(props: { event: GameEvent; index: number }) {
 }
 
 function GameOverView(props: { event: GameEvent; index: number }) {
-  const { event, index } = props;
+  const { event } = props;
 
   if (event.type !== "game_over") {
     return <></>;

--- a/frontend/src/components/GameStatusBoard.tsx
+++ b/frontend/src/components/GameStatusBoard.tsx
@@ -1,119 +1,124 @@
-import React, {useContext, useState} from "react";
-import {Seen} from "@/types";
-import {GameContext} from "@/providers";
-import CopyToClipboard from 'react-copy-to-clipboard';
-import {Button} from "@chakra-ui/react";
+import { GameContext } from "@/providers";
+import { Seen } from "@/types";
+import { Button } from "@chakra-ui/react";
+import { useContext, useState } from "react";
+import CopyToClipboard from "react-copy-to-clipboard";
 
 function PlayerItem(props: { index: number; name: string }) {
-    if (props.name === "-") {
-        return (
-            <div className="bg-gray-400 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center">
-                玩家{props.index}：-
-            </div>
-        );
-    }
-
+  if (props.name === "-") {
     return (
-        <div className="bg-amber-200 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center">
-            玩家{props.index}：{props.name}
-        </div>
+      <div className="bg-gray-400 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center">
+        玩家{props.index}：-
+      </div>
     );
+  }
+
+  return (
+    <div className="bg-amber-200 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center">
+      玩家{props.index}：{props.name}
+    </div>
+  );
 }
 
 export function SeenItem(props: { seen: Seen }) {
-    const {seen} = props;
-    return (
-        <>
-            <div className="text-gray-600">
-                看到 {seen.opponent_name} 持有 {seen.card.name}
-            </div>
-        </>
-    );
+  const { seen } = props;
+  return (
+    <>
+      <div className="text-gray-600">
+        看到 {seen.opponent_name} 持有 {seen.card.name}
+      </div>
+    </>
+  );
 }
 
 export function GameStatusBoard() {
-    const [copied, setCopied] = useState(false);
-    const context = useContext(GameContext);
-    if (!context.isReady()) {
-        return <></>;
+  const [copied, setCopied] = useState(false);
+  const context = useContext(GameContext);
+  if (!context.isReady()) {
+    return <></>;
+  }
+
+  const gameStatus = context.getGameStatus();
+  let gameProgress = "...(未知)...";
+
+  const data = [
+    { name: "-", index: 1 },
+    { name: "-", index: 2 },
+    { name: "-", index: 3 },
+    { name: "-", index: 4 },
+  ];
+
+  if (gameStatus != null) {
+    gameStatus.players.map((p, idx) => {
+      data[idx] = { name: p.name, index: idx + 1 };
+    });
+  }
+
+  // game has not stared, use the top player list
+  if (gameStatus != null && gameStatus.rounds.length === 0) {
+    gameProgress = "等待玩家加入中...";
+    if (gameStatus.players.length >= 2) {
+      gameProgress = "等待遊戲開始...";
     }
+  }
 
-    const gameStatus = context.getGameStatus();
-    let gameProgress = "...(未知)...";
+  let seens: Array<Seen> = [];
 
-    const data = [
-        {name: "-", index: 1},
-        {name: "-", index: 2},
-        {name: "-", index: 3},
-        {name: "-", index: 4},
-    ];
+  // the game has started
+  if (gameStatus != null && gameStatus.rounds.length > 0) {
+    const current_round = gameStatus.rounds[gameStatus.rounds.length - 1];
+    gameProgress = `等待 ${current_round.turn_player.name} 出牌...`;
 
-    if (gameStatus != null) {
-        gameStatus.players.map((p, idx) => {
-            data[idx] = {name: p.name, index: idx + 1};
-        });
-    }
+    current_round.players.map((p) => {
+      if (p.name === context.getUsername()) {
+        seens = p.seen_cards;
+      }
+    });
+  }
 
-    // game has not stared, use the top player list
-    if (gameStatus != null && gameStatus.rounds.length === 0) {
-        gameProgress = "等待玩家加入中...";
-        if (gameStatus.players.length >= 2) {
-            gameProgress = "等待遊戲開始...";
-        }
-    }
+  if (context.isGameOver()) {
+    gameProgress = "遊戲結束";
+  }
 
-    let seens: Array<Seen> = [];
-
-    // the game has started
-    if (gameStatus != null && gameStatus.rounds.length > 0) {
-        const current_round = gameStatus.rounds[gameStatus.rounds.length - 1];
-        gameProgress = `等待 ${current_round.turn_player.name} 出牌...`;
-
-        current_round.players.map((p) => {
-            if (p.name === context.getUsername()) {
-                seens = p.seen_cards;
-            }
-        });
-    }
-
-    if (context.isGameOver()) {
-        gameProgress = "遊戲結束";
-    }
-
-    return (
-        <>
-            <div className="mb-5">
-                <h1>遊戲狀態</h1>
-                <div
-                    className="bg-gray-100 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center border-2 border-red-700">
-                    {gameProgress}
-                </div>
-                <h1>玩家列表</h1>
-                {data.map((x) => (
-                    <PlayerItem index={x.index} name={x.name} key={`PlayerItem_${x.index}`}></PlayerItem>
-                ))}
-            </div>
-            <div className="absolute top-2 left-2 border-2 border-black p-1 text-[10pt]">
-                <div>玩家資訊</div>
-                <div>
-                    gameId: {gameStatus?.game_id}
-                    <CopyToClipboard text={gameStatus?.game_id} onCopy={() => {setCopied(true)}}>
-                        <Button
-                            rounded="5px"
-                            size="xs"
-                            margin="5px"
-                            marginTop="0px"
-                        >Copy</Button>
-                    </CopyToClipboard>
-                    {copied ? <span style={{color: 'red'}}>Copied.</span> : null}
-                </div>
-                <div>
-                    看到的牌：
-                    {seens.map((x, index) => (
-                        <SeenItem seen={x} key={`SeenItem_${x.card}`}/>
-                    ))}
-                </div>
-            </div>
-        </>
-    );
+  return (
+    <>
+      <div className="mb-5">
+        <h1>遊戲狀態</h1>
+        <div className="bg-gray-100 m-4 p-2 min-h-[3rem] pl-3 rounded-xl flex items-center border-2 border-red-700">
+          {gameProgress}
+        </div>
+        <h1>玩家列表</h1>
+        {data.map((x) => (
+          <PlayerItem
+            index={x.index}
+            name={x.name}
+            key={`PlayerItem_${x.index}`}
+          ></PlayerItem>
+        ))}
+      </div>
+      <div className="absolute top-2 left-2 border-2 border-black p-1 text-[10pt]">
+        <div>玩家資訊</div>
+        <div>
+          gameId: {gameStatus?.game_id}
+          <CopyToClipboard
+            text={gameStatus?.game_id}
+            onCopy={() => {
+              setCopied(true);
+            }}
+          >
+            <Button rounded="5px" size="xs" margin="5px" marginTop="0px">
+              Copy
+            </Button>
+          </CopyToClipboard>
+          {copied ? <span style={{ color: "red" }}>Copied.</span> : null}
+        </div>
+        <div>
+          看到的牌：
+          {seens.map((x, index) => (
+            <SeenItem seen={x} key={`SeenItem_${x.card}`} />
+          ))}
+        </div>
+      </div>
+    </>
+  );
 }

--- a/frontend/src/components/GameStatusBoard.tsx
+++ b/frontend/src/components/GameStatusBoard.tsx
@@ -49,7 +49,7 @@ export function GameStatusBoard() {
   ];
 
   if (gameStatus != null) {
-    gameStatus.players.map((p, idx) => {
+    gameStatus.players.forEach((p, idx) => {
       data[idx] = { name: p.name, index: idx + 1 };
     });
   }
@@ -69,7 +69,7 @@ export function GameStatusBoard() {
     const current_round = gameStatus.rounds[gameStatus.rounds.length - 1];
     gameProgress = `等待 ${current_round.turn_player.name} 出牌...`;
 
-    current_round.players.map((p) => {
+    current_round.players.forEach((p) => {
       if (p.name === context.getUsername()) {
         seens = p.seen_cards;
       }

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from "./useGameId";
+export * from "./usePollGameStatus";
+export * from "./useUsername";

--- a/frontend/src/hooks/useGameId.ts
+++ b/frontend/src/hooks/useGameId.ts
@@ -1,0 +1,5 @@
+import { useLocalStorage } from "./useLocalStorage";
+
+export function useGameId(): ReturnType<typeof useLocalStorage> {
+  return useLocalStorage("gameId");
+}

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-function useStorage(key: string): [string, (name: string) => void] {
+export function useLocalStorage(key: string) {
   const initial_value =
     window.localStorage.getItem(key) == null
       ? ""
@@ -13,13 +13,5 @@ function useStorage(key: string): [string, (name: string) => void] {
       window.localStorage.setItem(key, newValue);
       setValue(newValue);
     },
-  ];
-}
-
-export function useUsername(): [string, (name: string) => void] {
-  return useStorage("username");
-}
-
-export function useGameId(): [string, (name: string) => void] {
-  return useStorage("gameId");
+  ] as const;
 }

--- a/frontend/src/hooks/usePollGameStatus.ts
+++ b/frontend/src/hooks/usePollGameStatus.ts
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useState } from "react";
 
 /** Keep game status updated by polling. */
 export function usePollGameStatus(gameId: string, username: string) {
-  // TODO: break down GameStatus to separate states.
   const [gameStatus, setGameStatus] = useState<GameStatus | null>(null);
 
   const getCurrentGameStatus = useCallback(() => {

--- a/frontend/src/hooks/usePollGameStatus.ts
+++ b/frontend/src/hooks/usePollGameStatus.ts
@@ -1,0 +1,34 @@
+import { getGameStatus } from "@/apis";
+import { GameStatus } from "@/types";
+import isEqual from "lodash/isEqual";
+import { useCallback, useEffect, useState } from "react";
+
+/** Keep game status updated by polling. */
+export function usePollGameStatus(gameId: string, username: string) {
+  // TODO: break down GameStatus to separate states.
+  const [gameStatus, setGameStatus] = useState<GameStatus | null>(null);
+
+  const getCurrentGameStatus = useCallback(() => {
+    return getGameStatus(gameId, username).then((status: GameStatus) => {
+      setGameStatus((currentStatus) =>
+        !isEqual(currentStatus, status) ? status : currentStatus
+      );
+    });
+  }, [gameId, username]);
+
+  // refresh GameStatus every 1 second.
+  useEffect(() => {
+    // set GameStatus before the refresher triggered
+    getCurrentGameStatus();
+
+    const intervalId = setInterval(() => {
+      // auto-refresh GameStatus
+      getCurrentGameStatus();
+    }, 1 * 1000);
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [getCurrentGameStatus]);
+
+  return gameStatus;
+}

--- a/frontend/src/hooks/useUsername.ts
+++ b/frontend/src/hooks/useUsername.ts
@@ -1,0 +1,5 @@
+import { useLocalStorage } from "./useLocalStorage";
+
+export function useUsername(): ReturnType<typeof useLocalStorage> {
+  return useLocalStorage("username");
+}

--- a/frontend/src/providers/index.tsx
+++ b/frontend/src/providers/index.tsx
@@ -126,6 +126,7 @@ export function GameDataProvider(props: GameDataProviderProps) {
   const [username] = useUsername();
   const gameStatus = usePollGameStatus(gameId, username);
 
+  // Re-render only if the value of gameStatus and username got re-assigned.
   const value = useMemo(
     () =>
       gameStatus !== null

--- a/frontend/src/providers/index.tsx
+++ b/frontend/src/providers/index.tsx
@@ -1,8 +1,8 @@
-import { GameStatus, TurnPlayer } from "@/types";
-import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
-import { useGameId, useUsername } from "@/hooks";
 import { getGameStatus } from "@/apis";
+import { useGameId, useUsername } from "@/hooks";
+import { GameStatus, TurnPlayer } from "@/types";
 import { isEqual } from "lodash";
+import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 
 export interface GameInformation {
   getGameId: () => string;
@@ -150,10 +150,15 @@ export function GameDataProvider(props: GameDataProviderProps) {
     };
   }, []);
 
-  let value: GameInformation = new BeforeReadyGameInformation();
-  if (gameStatus !== null) {
-    value = new ConcreteGameInformation(gameId, username, gameStatus);
-  }
+  const value = useMemo(
+    () =>
+      gameStatus !== null
+        ? new ConcreteGameInformation(gameId, username, gameStatus)
+        : new BeforeReadyGameInformation(),
+
+    [gameStatus, gameId, username]
+  );
+
   return (
     <GameContext.Provider value={value}>{props.children}</GameContext.Provider>
   );

--- a/frontend/src/providers/index.tsx
+++ b/frontend/src/providers/index.tsx
@@ -86,7 +86,7 @@ class ConcreteGameInformation implements GameInformation {
   }
 
   isReady(): boolean {
-    return this.gameStatus != null;
+    return this.gameStatus !== null;
   }
 
   isMyTurn(): boolean {
@@ -104,7 +104,8 @@ class ConcreteGameInformation implements GameInformation {
 
   isGameOver(): boolean {
     return (
-      this.gameStatus.final_winner != "" && this.gameStatus.final_winner != null
+      this.gameStatus.final_winner !== "" &&
+      this.gameStatus.final_winner != null
     );
   }
 


### PR DESCRIPTION
目前 `gameStatus` 會隨著每次渲染就會被重新賦值，於是 `GameData` context會隨其父元件渲染而重新渲染。這個PR將舊value放入useMemo，確保GameData context未來不會因為其他因素重新渲染。

另外，引用lodash僅需引用使用到的功能，這樣可以避免將dead code包到bundle裡，如下：
```
import isEqual from "lodash/isEqual"
```

換成這樣的引用法，最後的bundle減少了19kb。

<img width="632" alt="Screenshot 2023-03-26 at 13 07 59" src="https://user-images.githubusercontent.com/627607/227771675-6619df0c-3c57-41c9-9e07-63a344439bc1.png">

