### PR TITLE
[Chore] Rewrite usecases for domain events and presenter

### DIFF
--- a/love_letter/models/event.py
+++ b/love_letter/models/event.py
@@ -1,0 +1,2 @@
+class DomainEvent:
+    pass

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -1,7 +1,0 @@
-from love_letter.models import Game
-from love_letter.repository import create_default_repository
-from love_letter.usecase.create_game import CreateGame
-from love_letter.usecase.get_status import GetStatus
-from love_letter.usecase.join_game import JoinGame
-from love_letter.usecase.play_card import PlayCard
-from love_letter.usecase.start_game import StartGame

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -3,34 +3,9 @@ from typing import Dict, Union
 
 from love_letter.models import Game, GuessCard, Player, ToSomeoneCard
 from love_letter.repository import create_default_repository
+from love_letter.usecase.create_game import CreateGame
 
 game_repository = create_default_repository()
-
-
-class CreateGameInput:
-    player_id: str
-
-
-class CreateGameOutput:
-    game_id: str
-
-
-class CreateGame:
-    def execute(self, input: CreateGameInput, output: CreateGameOutput):
-        game = Game()
-        game.join(Player(input.player_id))
-        game_id = game_repository.save_or_update(game)
-        output.game_id = game_id
-
-    @classmethod
-    def input(cls, player_id: str) -> CreateGameInput:
-        input = CreateGameInput()
-        input.player_id = player_id
-        return input
-
-    @classmethod
-    def output(cls) -> CreateGameOutput:
-        return CreateGameOutput()
 
 
 class JoinGameInput:

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -1,55 +1,11 @@
-import traceback
-from typing import Dict, Union
-
-from love_letter.models import Game, GuessCard, Player, ToSomeoneCard
+from love_letter.models import Game
 from love_letter.repository import create_default_repository
 from love_letter.usecase.create_game import CreateGame
 from love_letter.usecase.join_game import JoinGame
+from love_letter.usecase.play_card import PlayCard
 from love_letter.usecase.start_game import StartGame
 
 game_repository = create_default_repository()
-
-
-class PlayCardInput:
-    game_id: str
-    player_id: str
-    card_name: str
-    card_action: Union[GuessCard, ToSomeoneCard, None]
-
-
-class PlayCardOutput:
-    game: Game
-
-
-class PlayCard:
-    @classmethod
-    def output(cls) -> PlayCardOutput:
-        return PlayCardOutput()
-
-    @classmethod
-    def input(
-        cls,
-        game_id: str,
-        player_id: str,
-        card_name: str,
-        card_action: Union[GuessCard, ToSomeoneCard, None],
-    ) -> PlayCardInput:
-        input = PlayCardInput()
-        input.game_id = game_id
-        input.player_id = player_id
-        input.card_name = card_name
-        input.card_action = card_action
-        return input
-
-    def execute(self, input: PlayCardInput, output: PlayCardOutput):
-        game: Game = game_repository.get(input.game_id)
-        if game is None:
-            output.game = None
-            return
-
-        game.play(input.player_id, input.card_name, input.card_action)
-        game_repository.save_or_update(game)
-        output.game = game
 
 
 class GetStatusInput:

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -5,38 +5,9 @@ from love_letter.models import Game, GuessCard, Player, ToSomeoneCard
 from love_letter.repository import create_default_repository
 from love_letter.usecase.create_game import CreateGame
 from love_letter.usecase.join_game import JoinGame
+from love_letter.usecase.start_game import StartGame
 
 game_repository = create_default_repository()
-
-
-class StartGameInput:
-    game_id: str
-
-
-class StartGameOutput:
-    success: bool
-
-
-class StartGame:
-    @classmethod
-    def output(cls) -> StartGameOutput:
-        return StartGameOutput()
-
-    @classmethod
-    def input(cls, game_id) -> StartGameInput:
-        input = StartGameInput()
-        input.game_id = game_id
-        return input
-
-    def execute(self, input: StartGameInput, output: StartGameOutput):
-        game: Game = game_repository.get(input.game_id)
-        if game is None:
-            output.success = False
-            return
-
-        game.start()
-        game_repository.save_or_update(game)
-        output.success = True
 
 
 class PlayCardInput:

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -4,41 +4,9 @@ from typing import Dict, Union
 from love_letter.models import Game, GuessCard, Player, ToSomeoneCard
 from love_letter.repository import create_default_repository
 from love_letter.usecase.create_game import CreateGame
+from love_letter.usecase.join_game import JoinGame
 
 game_repository = create_default_repository()
-
-
-class JoinGameInput:
-    game_id: str
-    player_id: str
-
-
-class JoinGameOutput:
-    success: bool
-
-
-class JoinGame:
-    def execute(self, input: JoinGameInput, output: JoinGameOutput):
-        try:
-            game = game_repository.get(input.game_id)
-            game.join(Player(input.player_id))
-            game_repository.save_or_update(game)
-            output.success = True
-        except BaseException as e:
-            traceback.print_exception(e)
-            output.success = False
-
-    @classmethod
-    def output(cls) -> JoinGameOutput:
-        output = JoinGameOutput()
-        return output
-
-    @classmethod
-    def input(cls, game_id: str, player_id: str) -> JoinGameInput:
-        input = JoinGameInput()
-        input.game_id = game_id
-        input.player_id = player_id
-        return input
 
 
 class StartGameInput:

--- a/love_letter/usecase/__init__.py
+++ b/love_letter/usecase/__init__.py
@@ -1,37 +1,7 @@
 from love_letter.models import Game
 from love_letter.repository import create_default_repository
 from love_letter.usecase.create_game import CreateGame
+from love_letter.usecase.get_status import GetStatus
 from love_letter.usecase.join_game import JoinGame
 from love_letter.usecase.play_card import PlayCard
 from love_letter.usecase.start_game import StartGame
-
-game_repository = create_default_repository()
-
-
-class GetStatusInput:
-    game_id: str
-    player_id: str
-
-
-class GetStatusOutput:
-    game: Game
-
-
-class GetStatus:
-    @classmethod
-    def output(cls) -> GetStatusOutput:
-        return GetStatusOutput()
-
-    @classmethod
-    def input(cls, game_id: str, player_id: str) -> GetStatusInput:
-        input = GetStatusInput()
-        input.game_id = game_id
-        input.player_id = player_id
-        return input
-
-    def execute(self, input: GetStatusInput, output: GetStatusOutput):
-        game: Game = game_repository.get(input.game_id)
-        if game is None:
-            output.game = None
-            return
-        output.game = game

--- a/love_letter/usecase/common.py
+++ b/love_letter/usecase/common.py
@@ -1,0 +1,19 @@
+import abc
+from typing import List
+
+from love_letter.models.event import DomainEvent
+from love_letter.repository import create_default_repository
+
+game_repository = create_default_repository()
+
+
+class Presenter(metaclass=abc.ABCMeta):
+    def __init__(self):
+        self.events: List[DomainEvent] = []
+
+    def present(self, events: List[DomainEvent]):
+        self.events = events
+
+    @abc.abstractmethod
+    def as_view_model(self):
+        pass

--- a/love_letter/usecase/create_game.py
+++ b/love_letter/usecase/create_game.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+
+from love_letter.models import Game, Player
+from love_letter.models.event import DomainEvent
+from love_letter.usecase.common import Presenter, game_repository
+
+
+class CreateGameInput:
+    player_id: str
+
+
+@dataclass
+class GameCreatedEvent(DomainEvent):
+    game_id: str
+
+
+class CreateGamePresenter(Presenter):
+    def as_view_model(self):
+        for event in self.events:
+            if isinstance(event, GameCreatedEvent):
+                return event.game_id
+
+
+class CreateGame:
+    def execute(self, input: CreateGameInput, presenter: Presenter):
+        game = Game()
+        game.join(Player(input.player_id))
+        game_id = game_repository.save_or_update(game)
+        presenter.present([GameCreatedEvent(game_id=game_id)])
+
+    @classmethod
+    def input(cls, player_id: str) -> CreateGameInput:
+        input = CreateGameInput()
+        input.player_id = player_id
+        return input
+
+    @classmethod
+    def presenter(cls) -> CreateGamePresenter:
+        return CreateGamePresenter()

--- a/love_letter/usecase/create_game.py
+++ b/love_letter/usecase/create_game.py
@@ -19,6 +19,7 @@ class CreateGamePresenter(Presenter):
         for event in self.events:
             if isinstance(event, GameCreatedEvent):
                 return event.game_id
+        raise BaseException("Game is unavailable.")
 
 
 class CreateGame:

--- a/love_letter/usecase/get_status.py
+++ b/love_letter/usecase/get_status.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+from love_letter.models import Game
+from love_letter.models.event import DomainEvent
+from love_letter.usecase.common import Presenter, game_repository
+
+
+class GetStatusInput:
+    game_id: str
+    player_id: str
+
+
+@dataclass
+class GetStatusEvent(DomainEvent):
+    game: Game
+
+
+class GetStatusPresenter(Presenter):
+    def as_view_model(self) -> Game:
+        for event in self.events:
+            if isinstance(event, GetStatusEvent):
+                return event.game
+        raise BaseException("Game is unavailable.")
+
+
+class GetStatus:
+    def execute(self, input: GetStatusInput, presenter: Presenter):
+        game: Game = game_repository.get(input.game_id)
+        presenter.present(events=[GetStatusEvent(game)])
+
+    @classmethod
+    def input(cls, game_id: str, player_id: str) -> GetStatusInput:
+        input = GetStatusInput()
+        input.game_id = game_id
+        input.player_id = player_id
+        return input
+
+    @classmethod
+    def presenter(cls) -> "GetStatusPresenter":
+        return GetStatusPresenter()

--- a/love_letter/usecase/join_game.py
+++ b/love_letter/usecase/join_game.py
@@ -21,10 +21,11 @@ class JoinGamePresenter(Presenter):
         for event in self.events:
             if isinstance(event, PlayerJoinedEvent):
                 return event.success
+        raise BaseException("Game is unavailable.")
 
 
 class JoinGame:
-    def execute(self, input: PlayerJoinGameInput, presenter: Presenter):
+    def execute(self, input: PlayerJoinGameInput, presenter: JoinGamePresenter):
         try:
             game = game_repository.get(input.game_id)
             game.join(Player(input.player_id))
@@ -42,5 +43,5 @@ class JoinGame:
         return input
 
     @classmethod
-    def presenter(cls) -> Presenter:
+    def presenter(cls) -> JoinGamePresenter:
         return JoinGamePresenter()

--- a/love_letter/usecase/join_game.py
+++ b/love_letter/usecase/join_game.py
@@ -1,0 +1,46 @@
+import traceback
+from dataclasses import dataclass
+
+from love_letter.models import Player
+from love_letter.models.event import DomainEvent
+from love_letter.usecase.common import Presenter, game_repository
+
+
+class PlayerJoinGameInput:
+    game_id: str
+    player_id: str
+
+
+@dataclass
+class PlayerJoinedEvent(DomainEvent):
+    success: bool
+
+
+class JoinGamePresenter(Presenter):
+    def as_view_model(self):
+        for event in self.events:
+            if isinstance(event, PlayerJoinedEvent):
+                return event.success
+
+
+class JoinGame:
+    def execute(self, input: PlayerJoinGameInput, presenter: Presenter):
+        try:
+            game = game_repository.get(input.game_id)
+            game.join(Player(input.player_id))
+            game_repository.save_or_update(game)
+            presenter.present([PlayerJoinedEvent(success=True)])
+        except BaseException as e:
+            traceback.print_exception(e)
+            presenter.present([PlayerJoinedEvent(success=False)])
+
+    @classmethod
+    def input(cls, game_id: str, player_id: str) -> PlayerJoinGameInput:
+        input = PlayerJoinGameInput()
+        input.game_id = game_id
+        input.player_id = player_id
+        return input
+
+    @classmethod
+    def presenter(cls) -> Presenter:
+        return JoinGamePresenter()

--- a/love_letter/usecase/play_card.py
+++ b/love_letter/usecase/play_card.py
@@ -1,0 +1,60 @@
+import traceback
+from dataclasses import dataclass
+from typing import Union
+
+from love_letter.models import Game, GuessCard, ToSomeoneCard
+from love_letter.models.event import DomainEvent
+from love_letter.usecase.common import Presenter, game_repository
+
+
+class PlayCardInput:
+    game_id: str
+    player_id: str
+    card_name: str
+    card_action: Union[GuessCard, ToSomeoneCard, None]
+
+
+@dataclass
+class CardPlayedEvent(DomainEvent):
+    game: Game
+
+
+class PlayCardPresenter(Presenter):
+    def as_view_model(self) -> Game:
+        for event in self.events:
+            if isinstance(event, CardPlayedEvent):
+                return event.game
+        raise BaseException("Game is unavailable.")
+
+
+class PlayCard:
+    def execute(self, input: PlayCardInput, presenter: Presenter):
+        try:
+            game: Game = game_repository.get(input.game_id)
+            if game is None:
+                raise BaseException(f"Game {input.game_id} is unavailable.")
+
+            game.play(input.player_id, input.card_name, input.card_action)
+            game_repository.save_or_update(game)
+            presenter.present([CardPlayedEvent(game)])
+        except BaseException as exception:
+            traceback.print_exception(exception)
+
+    @classmethod
+    def input(
+        cls,
+        game_id: str,
+        player_id: str,
+        card_name: str,
+        card_action: Union[GuessCard, ToSomeoneCard, None],
+    ) -> PlayCardInput:
+        input = PlayCardInput()
+        input.game_id = game_id
+        input.player_id = player_id
+        input.card_name = card_name
+        input.card_action = card_action
+        return input
+
+    @classmethod
+    def presenter(cls) -> "PlayCardPresenter":
+        return PlayCardPresenter()

--- a/love_letter/usecase/start_game.py
+++ b/love_letter/usecase/start_game.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+
+from love_letter.models import Game
+from love_letter.models.event import DomainEvent
+from love_letter.usecase.common import Presenter, game_repository
+
+
+class StartGameInput:
+    game_id: str
+
+
+@dataclass
+class StartGameEvent(DomainEvent):
+    success: bool
+
+
+class StartGamePresenter(Presenter):
+    def as_view_model(self):
+        for event in self.events:
+            if isinstance(event, StartGameEvent):
+                return event.success
+
+
+class StartGame:
+    def execute(self, input: StartGameInput, presenter: Presenter):
+        game: Game = game_repository.get(input.game_id)
+        if game is None:
+            presenter.present([StartGameEvent(success=False)])
+            return
+
+        game.start()
+        game_repository.save_or_update(game)
+        presenter.present([StartGameEvent(success=True)])
+
+    @classmethod
+    def input(cls, game_id) -> StartGameInput:
+        input = StartGameInput()
+        input.game_id = game_id
+        return input
+
+    @classmethod
+    def presenter(cls) -> Presenter:
+        return StartGamePresenter()

--- a/love_letter/usecase/start_game.py
+++ b/love_letter/usecase/start_game.py
@@ -19,6 +19,7 @@ class StartGamePresenter(Presenter):
         for event in self.events:
             if isinstance(event, StartGameEvent):
                 return event.success
+        raise BaseException("Game is unavailable.")
 
 
 class StartGame:

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -41,9 +41,9 @@ async def create_game(player_id: str) -> str:
 
 @app.post("/games/{game_id}/player/{player_id}/join")
 async def join_game(game_id: str, player_id: str) -> bool:
-    output = JoinGame.output()
-    JoinGame().execute(JoinGame.input(game_id, player_id), output)
-    return output.success
+    presenter = JoinGame.presenter()
+    JoinGame().execute(JoinGame.input(game_id, player_id), presenter)
+    return presenter.as_view_model()
 
 
 @app.post("/games/{game_id}/start")

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -34,9 +34,9 @@ app.add_middleware(
 
 @app.post("/games/create/by_player/{player_id}")
 async def create_game(player_id: str) -> str:
-    output = CreateGame.output()
-    CreateGame().execute(CreateGame.input(player_id), output)
-    return output.game_id
+    presenter = CreateGame.presenter()
+    CreateGame().execute(CreateGame.input(player_id), presenter)
+    return presenter.as_view_model()
 
 
 @app.post("/games/{game_id}/player/{player_id}/join")

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -48,9 +48,9 @@ async def join_game(game_id: str, player_id: str) -> bool:
 
 @app.post("/games/{game_id}/start")
 async def start_game(game_id: str):
-    output = StartGame.output()
-    StartGame().execute(StartGame.input(game_id), output)
-    return output.success
+    presenter = StartGame.presenter()
+    StartGame().execute(StartGame.input(game_id), presenter)
+    return presenter.as_view_model()
 
 
 @app.post(

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -7,7 +7,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from love_letter.models import GuessCard, ToSomeoneCard
 
 # isort: off
-from love_letter.usecase import CreateGame, GetStatus, JoinGame, PlayCard, StartGame
+
+from love_letter.usecase.create_game import CreateGame
+from love_letter.usecase.get_status import GetStatus
+from love_letter.usecase.join_game import JoinGame
+from love_letter.usecase.play_card import PlayCard
+from love_letter.usecase.start_game import StartGame
 
 # isort: on
 from love_letter.web.dto import GameStatus

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -4,7 +4,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from love_letter.models import GuessCard, ToSomeoneCard
+from love_letter.models import Game, GuessCard, ToSomeoneCard
 from love_letter.repository import create_default_repository
 
 # isort: off
@@ -63,11 +63,12 @@ async def play_card(
     card_name: str,
     card_action: Union[GuessCard, ToSomeoneCard, None] = None,
 ):
-    output = PlayCard.output()
+    presenter = PlayCard.presenter()
     PlayCard().execute(
-        PlayCard.input(game_id, player_id, card_name, card_action), output
+        PlayCard.input(game_id, player_id, card_name, card_action), presenter
     )
-    return build_player_view(output.game, player_id)
+    game = presenter.as_view_model()
+    return build_player_view(game, player_id)
 
 
 @app.get("/games/{game_id}/player/{player_id}/status", response_model=GameStatus)

--- a/love_letter/web/app.py
+++ b/love_letter/web/app.py
@@ -4,8 +4,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from love_letter.models import Game, GuessCard, ToSomeoneCard
-from love_letter.repository import create_default_repository
+from love_letter.models import GuessCard, ToSomeoneCard
 
 # isort: off
 from love_letter.usecase import CreateGame, GetStatus, JoinGame, PlayCard, StartGame
@@ -73,9 +72,10 @@ async def play_card(
 
 @app.get("/games/{game_id}/player/{player_id}/status", response_model=GameStatus)
 async def get_status(game_id: str, player_id: str):
-    output = GetStatus.output()
-    GetStatus().execute(GetStatus.input(game_id, player_id), output)
-    return build_player_view(output.game, player_id)
+    presenter = GetStatus.presenter()
+    GetStatus().execute(GetStatus.input(game_id, player_id), presenter)
+    game = presenter.as_view_model()
+    return build_player_view(game, player_id)
 
 
 def run():

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -4,7 +4,12 @@ from love_letter.models import Game, Player, Round, ToSomeoneCard
 from love_letter.repository import create_default_repository
 
 # isort: off
-from love_letter.usecase import CreateGame, GetStatus, JoinGame, PlayCard, StartGame
+
+from love_letter.usecase.create_game import CreateGame
+from love_letter.usecase.get_status import GetStatus
+from love_letter.usecase.join_game import JoinGame
+from love_letter.usecase.play_card import PlayCard
+from love_letter.usecase.start_game import StartGame
 
 # isort: on
 from love_letter.web.dto import GameStatus

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -57,10 +57,9 @@ class GameServiceTests(unittest.TestCase):
         return output
 
     def create_game(self):
-        output = CreateGame.output()
-        CreateGame().execute(CreateGame.input("1"), output)
-        game_id = output.game_id
-        return game_id
+        presenter = CreateGame.presenter()
+        CreateGame().execute(CreateGame.input("1"), presenter)
+        return presenter.as_view_model()
 
     def test_get_status(self):
         repo = create_default_repository()

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -196,7 +196,7 @@ class PlayerContextTest(unittest.TestCase):
 
         # when player-1 discard countess
         PlayCard().execute(
-            PlayCard.input(self.game_id, "1", "伯爵夫人", None), PlayCard.output()
+            PlayCard.input(self.game_id, "1", "伯爵夫人", None), PlayCard.presenter()
         )
 
         expected_card_mapping = {
@@ -355,7 +355,7 @@ class PlayerContextTest(unittest.TestCase):
         # when: 1對3打出神父
         PlayCard().execute(
             PlayCard.input(self.game_id, "1", "神父", ToSomeoneCard(chosen_player=3)),
-            PlayCard.output(),
+            PlayCard.presenter(),
         )
 
         status_of_player1: GameStatus = GameStatus.parse_obj(

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -69,9 +69,9 @@ class GameServiceTests(unittest.TestCase):
         game_id = self.create_game()
         self.join_game(game_id)
 
-        output = StartGame.output()
-        StartGame().execute(StartGame.input(game_id), output)
-        self.assertTrue(output.success)
+        presenter = StartGame.presenter()
+        StartGame().execute(StartGame.input(game_id), presenter)
+        self.assertTrue(presenter.as_view_model())
 
         # when get game status
         status_of_player1: GameStatus = GameStatus.parse_obj(get_status(game_id, "1"))
@@ -377,5 +377,5 @@ class PlayerContextTest(unittest.TestCase):
         )  # turn_player = 玩家2
 
     def start_game(self, game_id):
-        output = StartGame.output()
-        StartGame().execute(StartGame.input(game_id), output)
+        presenter = StartGame.presenter()
+        StartGame().execute(StartGame.input(game_id), presenter)

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -12,10 +12,11 @@ from love_letter.web.presenter import build_player_view
 from tests.test_card_behave import reset_deck
 
 
-def get_status(game_id, player_id):
-    output = GetStatus.output()
-    GetStatus().execute(GetStatus.input(game_id, player_id), output)
-    result = build_player_view(output.game, player_id)
+def get_status(game_id: str, player_id: str):
+    presenter = GetStatus.presenter()
+    GetStatus().execute(GetStatus.input(game_id, player_id), presenter)
+    game = presenter.as_view_model()
+    result = build_player_view(game, player_id)
     return result
 
 
@@ -62,7 +63,7 @@ class GameServiceTests(unittest.TestCase):
         return presenter.as_view_model()
 
     def test_get_status(self):
-        repo = create_default_repository()
+        create_default_repository()
 
         # given a started game with two players
         # create a new game by usecase

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -26,7 +26,7 @@ class GameServiceTests(unittest.TestCase):
         self.assertIsNotNone(game_id)
 
         # join the second player
-        self.assertTrue(self.join_game(game_id).success)
+        self.assertTrue(self.join_game(game_id))
         result = get_status(game_id, "1")
 
         self.assertIsNotNone(result)
@@ -52,9 +52,9 @@ class GameServiceTests(unittest.TestCase):
         self.assertEqual("['1', '2']", str(names))
 
     def join_game(self, game_id):
-        output = JoinGame.output()
-        JoinGame().execute(JoinGame.input(game_id, "2"), output)
-        return output
+        presenter = JoinGame.presenter()
+        JoinGame().execute(JoinGame.input(game_id, "2"), presenter)
+        return presenter.as_view_model()
 
     def create_game(self):
         presenter = CreateGame.presenter()
@@ -67,7 +67,7 @@ class GameServiceTests(unittest.TestCase):
         # given a started game with two players
         # create a new game by usecase
         game_id = self.create_game()
-        output = self.join_game(game_id)
+        self.join_game(game_id)
 
         output = StartGame.output()
         StartGame().execute(StartGame.input(game_id), output)


### PR DESCRIPTION
## Goals

Rewrite usecases to apply domain-event to presenter

- [x] create game (@qrtt1 )
- [x] join game (@qrtt1 )
- [x] start game(@s9891326 )
- [x] play card (@iannbing )
- [x] get status  (@iannbing )

## Non-goals

The presenter implementation should be in the `interface adapter` layer, but we put it in the `application` layer for now. 
> Keep the structure, refactoring later.

<img src="https://user-images.githubusercontent.com/193223/231672361-b96981bb-2458-47c5-853d-ded4fdc45bce.png" height="240">
